### PR TITLE
dark mode default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,14 +4,13 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { ChakraProvider, ColorModeScript } from '@chakra-ui/react';
+import theme from './theme';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <ChakraProvider>
-      <ColorModeScript 
-          initialColorMode='light'>
-      </ColorModeScript>
+    <ColorModeScript initialColorMode={theme.config.initialColorMode} />
     <App />
     
     </ChakraProvider>

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,10 @@
+import { extendTheme } from '@chakra-ui/react'
+
+const config = {
+  initialColorMode: 'dark',
+  useSystemColorMode: false,
+}
+
+const theme = extendTheme({ config })
+
+export default theme


### PR DESCRIPTION
dark mode should be the default now, i tested on my system using "npm start" and it displays in dark mode on start up. another option could be to use the end users system settings to decide the color mode on start up, the appears like it can be done by just changing the useSystemColorMode prop to true which i left in for this reason.